### PR TITLE
updated "e2e" BP path

### DIFF
--- a/components/mcac45/scripts/manager_configure.sh
+++ b/components/mcac45/scripts/manager_configure.sh
@@ -21,7 +21,7 @@ sudo -u centos  cfy install \
     --timeout 1800 \
     -n blueprint.yaml \
     -b "e2e" \
-    "https://github.com/Cloudify-PS/e2e-deployment/archive/v6.zip" >> /tmp/cfy_status.txt 2>&1 &
+    "https://github.com/Cloudify-PS/e2e-deployment/archive/v7.zip" >> /tmp/cfy_status.txt 2>&1 &
 
 # Add AWS DB Blueprint
 sudo -u centos  cfy blueprints upload -n aws.yaml \


### PR DESCRIPTION
updated "e2e" BP path so its internal wordpress_blueprint_archive is correct (v7)